### PR TITLE
add mac m1 chip arm64 support

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -31,7 +31,7 @@ install_opam() {
     x86_64) architecture="x86_64" ;;
     i686) architecture="i686" ;;
     armv7l) architecture="armhf" ;;
-    arm | aarch64) architecture="arm64" ;;
+    arm | arm64 | aarch64) architecture="arm64" ;;
     *) fail "Unsupported architecture" ;;
   esac
 


### PR DESCRIPTION
output of `uname -m`:
`arm64`

prior to this change installing opam would give the following error
`\e[31mFail:\e[m Unsupported architecture`